### PR TITLE
Release v2023.06.03

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include naif_eop_predict/earth_200101_990628_predict.bpc
-include naif_eop_predict/earth_200101_990628_predict.md5
+include naif_eop_predict/earth_200101_990825_predict.bpc
+include naif_eop_predict/earth_200101_990825_predict.md5

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 [![Build and Test](https://github.com/B612-Asteroid-Institute/naif_eop_predict/actions/workflows/build_test.yml/badge.svg)](https://github.com/B612-Asteroid-Institute/naif_eop_predict/actions/workflows/build_test.yml)
 [![Build, Test, & Publish](https://github.com/B612-Asteroid-Institute/naif_eop_predict/actions/workflows/build_test_publish.yml/badge.svg)](https://github.com/B612-Asteroid-Institute/naif_eop_predict/actions/workflows/build_test_publish.yml)  
 
-This package ships the Navigation and Ancillary Information Facility's low accuracy, longterm prediction Earth orientation parameters (EOP) [kernel](https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/earth_200101_990628_predict.bpc).
+This package ships the Navigation and Ancillary Information Facility's low accuracy, longterm prediction Earth orientation parameters (EOP) [kernel](https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/earth_200101_990825_predict.bpc).
 
 **This is not an official NAIF package**. It is an automatically generated mirror of the file so that it is
 installable via `pip`. 
 
-The current version of the file released on 2020 APR 11 spans the following times: 2020 JAN 01 00:01:09.183 TDB - 2099 JUN 28 00:01:09.182 TDB
+The current version of the file released on 2023 JUN 03 spans the following times: 2020 JAN 01 00:01:09.183 TDB - 2099 AUG 25 00:01:09.182 TDB
 
 ## Installation
 

--- a/naif_eop_predict/__init__.py
+++ b/naif_eop_predict/__init__.py
@@ -1,4 +1,4 @@
 from importlib.resources import files
 
-eop_predict = files("naif_eop_predict").joinpath("earth_200101_990628_predict.bpc").as_posix()
-_eop_predict_md5 = files("naif_eop_predict").joinpath("earth_200101_990628_predict.md5").as_posix()
+eop_predict = files("naif_eop_predict").joinpath("earth_200101_990825_predict.bpc").as_posix()
+_eop_predict_md5 = files("naif_eop_predict").joinpath("earth_200101_990825_predict.md5").as_posix()

--- a/naif_eop_predict/fetch.py
+++ b/naif_eop_predict/fetch.py
@@ -4,9 +4,9 @@ import os
 
 import requests
 
-URL = "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/earth_200101_990628_predict.bpc"
-FILE = os.path.join(os.path.dirname(__file__), "earth_200101_990628_predict.bpc")
-MD5_FILE = os.path.join(os.path.dirname(__file__), "earth_200101_990628_predict.md5")
+URL = "https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/earth_200101_990825_predict.bpc"
+FILE = os.path.join(os.path.dirname(__file__), "earth_200101_990825_predict.bpc")
+MD5_FILE = os.path.join(os.path.dirname(__file__), "earth_200101_990825_predict.md5")
 
 
 def fetch_file(url: str, output_file: str):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "naif_eop_predict"
-version = "2020.04.11" 
+version = "2023.06.03" 
 authors = [
     {name = "B612 Asteroid Institute", email = "info@b612foundation.org"},
 ]
@@ -22,4 +22,4 @@ tests = [
 include-package-data = true
 
 [tool.setuptools.package-data]
-naif_eop_predict = ["naif_eop_predict/earth_200101_990628_predict.bpc", "naif_eop_predict/earth_200101_990628_predict.md5"]
+naif_eop_predict = ["naif_eop_predict/earth_200101_990825_predict.bpc", "naif_eop_predict/earth_200101_990825_predict.md5"]


### PR DESCRIPTION
A new version of the long-term prediction EOP file was released this past week (first one in a little over three years): https://naif.jpl.nasa.gov/pub/naif/generic_kernels/pck/earth_200101_990825_predict.bpc

This PR adds a new version of the data package. 